### PR TITLE
add repository field to pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "lib": "babel src --out-dir lib",
     "build": "npm run test && npm run lint && npm run lib && npm run bundle"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mathieuancelin/react-context-utils.git"
+  },
   "author": "Mathieu ANCELIN",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
its nice, 'cause
- npm will show a link to repo on [package's page](https://www.npmjs.com/package/react-context-utils)
- npm will be able to open repo with `repo` command:  `$ npm repo react-context-utils`
